### PR TITLE
メールアドレス重複バグ修正

### DIFF
--- a/src/main/java/com/example/demo/controller/admin/UserController.java
+++ b/src/main/java/com/example/demo/controller/admin/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
 			return "admin/user/register";
 		}
 		// ▼ 追加: メールアドレスの重複チェック
-		if (userRepository.findByMail(form.getMail()) != null) {
+		if (!userRepository.findByMail(form.getMail()).isEmpty()) {
 			bindingResult.rejectValue("mail", "error.mail", "このメールアドレスは既に使用されています");
 			return "admin/user/register";
 		}


### PR DESCRIPTION
## チケット
なし
## 実装内容
新規会員登録で登録されていないメールアドレスでも重複エラーが表示されるバグを修正
## 確認したこと
未登録のメールアドレスでの新規登録、既存のメールアドレスでのログイン
## やらなかったこと
