### PR TITLE
商品一覧画面の作成（商品の表示はまだ）

### DIFF
--- a/src/main/java/com/example/demo/controller/user/ProductController.java
+++ b/src/main/java/com/example/demo/controller/user/ProductController.java
@@ -1,0 +1,16 @@
+package com.example.demo.controller.user;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller("UserController")
+public class ProductController {
+
+	@GetMapping("/")
+	public String topView(Model model, @PageableDefault(page = 0, size = 20) Pageable pageable) {
+		return "user/index";
+	}
+}

--- a/src/main/resources/static/css/user/common/header.css
+++ b/src/main/resources/static/css/user/common/header.css
@@ -1,0 +1,45 @@
+.products-search-form {
+	margin-top: 0.5rem;
+	margin-right: 0;
+	margin-left: 0;
+}
+
+@media (min-width: 576px) {
+	.products-search-form {
+		margin-top: 0.5rem !important;
+		margin-right: 0 !important;
+		margin-left: 0 !important;
+	}
+}
+
+@media (min-width: 768px) {
+	.products-search-form {
+		margin-top: 0.5rem !important;
+		margin-right: 0 !important;
+		margin-left: 0 !important;
+	}
+}
+
+@media (min-width: 992px) {
+	.products-search-form {
+		margin-top: 0 !important;
+		margin-right: 0 !important;
+		margin-left: 7rem !important;
+	}
+}
+
+@media (min-width: 1200px) {
+	.products-search-form {
+		margin-top: 0 !important;
+		margin-right: 3rem !important;
+		margin-left: 11rem !important;
+	}
+}
+
+@media (min-width: 1400px) {
+	.products-search-form {
+		margin-top: 0 !important;
+		margin-right: 7rem !important;
+		margin-left: 13rem !important;
+	}
+}

--- a/src/main/resources/static/css/user/index.css
+++ b/src/main/resources/static/css/user/index.css
@@ -1,0 +1,16 @@
+.card-title {
+	overflow: hidden;
+	display: -webkit-box;
+	line-clamp: 2;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+.card img {
+	aspect-ratio: 6 / 7;
+	object-fit: contain;
+}
+
+.text-not-decoration {
+	text-decoration: none;
+}

--- a/src/main/resources/templates/user/common/footer.html
+++ b/src/main/resources/templates/user/common/footer.html
@@ -1,0 +1,10 @@
+<footer class="bg-primary" xmlns:th="http://www.thymeleaf.org" th:fragment="footer_fragment">
+	<div class="footer-contents">
+		<div>
+			<span class="footer-logo">Spring EC</span>
+		</div>
+		<div>
+			<span class="copy-right">© 2024 Spring EC, Inc. All Rights Reserved</span>
+		</div>
+	</div>
+</footer>

--- a/src/main/resources/templates/user/common/head.html
+++ b/src/main/resources/templates/user/common/head.html
@@ -1,0 +1,14 @@
+<head xmlns:th="http://www.thymeleaf.org" th:fragment="meta_header(title,links,scripts)">
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+	<title th:text="${title}+' | Spring EC'"></title>
+
+	<link th:href="@{/css/common/bootstrap.css}" rel="stylesheet" />
+	<link th:href="@{/css/user/common/header.css}" rel="stylesheet" />
+	<script th:src="@{/js/common/bootstrap.js}" crossorigin="anonymous"></script>
+
+	<th:block th:replace="${links}" />
+	<th:block th:replace="${scripts}" />
+</head>

--- a/src/main/resources/templates/user/common/header.html
+++ b/src/main/resources/templates/user/common/header.html
@@ -1,0 +1,31 @@
+<header xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+	th:fragment="header_fragment">
+	<nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+		<div class="container-fluid">
+			<a class="navbar-brand" th:href="@{/}">
+				<h3>Spring EC</h3>
+			</a>
+			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarColor01"
+				aria-controls="navbarColor01" aria-expanded="false" aria-label="ナビゲーションの切り替え">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+			<div class="collapse navbar-collapse" id="navbarColor01">
+				<form class="d-flex flex-grow1 products-search-form" method="get" action="/">
+					<input class="form-control" type="search" name="name" th:value="${name}" placeholder="検索">
+					<button class="my-sm-0" type="submit"></button>
+				</form>
+				<ul class="navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link" th:href="@{/}">商品一覧</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" th:href="@{/login}">ログイン</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" th:href="@{/register}">新規登録</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</nav>
+</header>

--- a/src/main/resources/templates/user/index.html
+++ b/src/main/resources/templates/user/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{user/common/head :: meta_header('商品一覧',~{::link},~{})}">
+	<link th:href="@{/css/user/index.css}" rel="stylesheet" />
+</head>
+
+<body>
+	<div th:replace="~{user/common/header :: header_fragment}"></div>
+
+	<!-- --------------------------- -->
+	<!-- main -->
+	<main>
+		<h3 class="text-center mt-5">商品一覧</h3>
+		<div class="px-5 py-5">
+			<div class="container-fluid">
+				<div class="row">
+					<th:block th:if="${products == null && searchKeyword == null}">
+						<h4 class="text-center">現在商品が販売されていません。</h4>
+					</th:block>
+					<th:block th:if="${products == null && searchKeyword != null}">
+						<h4 class="text-center">"<span th:text="${searchKeyword}"></span>"に一致する商品は見つかりませんでした。</h4>
+					</th:block>
+					<th:block th:if="${products != null}" th:each="product : ${products}">
+						<div class="col-sm-6 col-md-6 col-lg-4 col-xl-3 col-xxl-2 py-3">
+							<a class="text-not-decoration" th:href="@{/{productId}(productId = ${product.productId})}">
+								<div class="card">
+									<img class="bg-light"
+										th:src="${#strings.isEmpty(product.imageUrl)} ? @{/img/no-image.png} : ${product.imageUrl}"
+										alt="">
+									<div class="card-body">
+										<h5 class="card-title" th:text="${product.name}"></h5>
+										<p th:if="${product.stock.quantity == 0}" class="card-text text-danger">現在在庫切れです
+										</p>
+										<p th:if="${product.stock.quantity > 0}" class="card-text"
+											th:text="'¥'+${#strings.length(product.amount) < 4 ? product.amount : #numbers.formatInteger(product.amount, 3, 'COMMA')}">
+										</p>
+									</div>
+								</div>
+							</a>
+						</div>
+					</th:block>
+				</div>
+			</div>
+		</div>
+
+		<!-- --------------------------- -->
+		<!-- pagenation -->
+		<ul class="pagination mb-5" th:if="${page != null}">
+			<li class="page-item" th:classappend="${page.first} ? 'disabled' : ''">
+				<a class="page-link" th:href="@{/(page = ${page.number} - 1)}">&laquo;</a>
+			</li>
+			<li th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}" class="page-item"
+				th:classappend="(${i} == ${page.number}) ? 'active' : ''">
+				<a class="page-link" th:href="@{/(page = ${i})}" th:text="${i + 1}"></a>
+			</li>
+			<li class="page-item" th:classappend="${page.last} ? 'disabled' : ''">
+				<a class="page-link" th:href="@{/(page = ${page.number} + 1)}">&raquo;</a>
+			</li>
+		</ul>
+		<!-- pagenation -->
+		<!-- --------------------------- -->
+	</main>
+	<!-- main -->
+	<!-- --------------------------- -->
+
+	<div th:replace="~{user/common/footer :: footer_fragment}"></div>
+</body>
+
+</html>


### PR DESCRIPTION
## チケット

https://github.com/Makoto-Ueno/spring_ec_site/issues/44

## 実装内容

商品一覧画面の作成(商品の表示はまだ)

## 確認したこと

トップページに遷移したら商品一覧画面が表示されること
<img width="1919" height="1015" alt="スクリーンショット 2025-11-08 23 06 12" src="https://github.com/user-attachments/assets/da7bb0a9-e887-4abc-ac6c-edeaff085e6c" />



## やらなかったこと
- 商品の表示
- 商品の検索