### PR TITLE
Feature/ユーザー新規登録画面

### DIFF
--- a/src/main/java/com/example/demo/controller/user/CustomerUserController.java
+++ b/src/main/java/com/example/demo/controller/user/CustomerUserController.java
@@ -1,0 +1,68 @@
+package com.example.demo.controller.user;
+
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.example.demo.entity.User;
+import com.example.demo.form.UserRegistForm;
+import com.example.demo.repository.UserRepository;
+
+@Controller
+public class CustomerUserController {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
+	
+	@GetMapping("/register")
+	public String registerView(Model model, UserRegistForm form) {
+		model.addAttribute(form);
+		return "user/user/register";
+	}
+
+	@PostMapping("/register")
+	public String register(Model model, @ModelAttribute @Validated UserRegistForm form, BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+		// ▼ パスワードと確認用パスワードが一致しているかをチェック
+		if (!form.getPassword().equals(form.getPasswordConfirm())) {
+			// ▼ 一致しない場合、BindingResultにエラーを追加
+			bindingResult.rejectValue("passwordConfirm", "error.passwordConfirm", "パスワードと入力が一致しません");
+		}
+		// ▼ バリデーションエラーがある場合、登録画面に戻る
+		if (bindingResult.hasErrors()) {
+			model.addAttribute(form);
+			return "user/user/register";
+		}
+		// ▼ 追加: メールアドレスの重複チェック
+		if (!userRepository.findByMail(form.getMail()).isEmpty()) {
+			bindingResult.rejectValue("mail", "error.mail", "このメールアドレスは既に使用されています");
+			return "user/user/register";
+		}
+
+		User user = new User();
+		user.setMail(form.getMail());
+		// ハッシュ化
+		var hashPassword = passwordEncoder.encode(form.getPassword());
+		user.setPassword(hashPassword);
+		user.setType(0);
+		Date now = new Date();
+		user.setCreateAt(now);
+		user.setUpdateAt(now);
+
+		userRepository.saveAndFlush(user);
+		return "redirect:/";
+	}
+
+}

--- a/src/main/resources/templates/user/user/register.html
+++ b/src/main/resources/templates/user/user/register.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{user/common/head :: meta_header('新規登録',~{},~{::script})}">
+	<script th:src="@{/js/common/password-mask.js}" crossorigin="anonymous"></script>
+</head>
+
+<body>
+	<div class="contents">
+		<div th:replace="~{user/common/header :: header_fragment}"></div>
+		<main class="px-5 py-6">
+			<div class="container-fluid">
+				<div class="row">
+					<form class="form-control col-sm-9 col-md-7 col-lg-6 col-xl-5 col-xxl-4 m-auto" action=""
+						method="post" th:object="${userRegistForm}">
+						<fieldset>
+							<div>
+								<label for="mail" class="form-label mt-4">メールアドレス</label>
+								<input type="text" th:field="*{mail}" class="form-control w-100"
+									placeholder="spring@gmail.com">
+								<div class="error-text" th:if="${#fields.hasErrors('mail')}" th:errors="*{mail}"
+									style="color: red;"></div>
+							</div>
+							<div>
+								<label for="password" class="form-label mt-4">パスワード</label>
+								<div class="form-control input-password">
+									<input type="password" th:field="*{password}" placeholder="6 ~ 16文字（半角英数字・記号）"
+										autocomplete="off">
+									<span class="is-mask" onclick="togglePasswordVisibility(this)"></span>
+								</div>
+								<div class="error-text" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"
+									style="color: red;"></div>
+							</div>
+							<div>
+								<label for="passwordConfirm" class="form-label mt-4">パスワード（確認）</label>
+								<div class="form-control input-password">
+									<input type="password" th:field="*{passwordConfirm}"
+										placeholder="6 ~ 16文字（半角英数字・記号）" autocomplete="off">
+									<span class="is-mask" onclick="togglePasswordVisibility(this)"></span>
+								</div>
+								<div class="error-text" th:if="${#fields.hasErrors('passwordConfirm')}"
+									th:errors="*{passwordConfirm}" style="color: red;"></div>
+							</div>
+							<div class="d-grid mt-5 mb-4">
+								<button class="btn btn-lg btn-secondary">新規登録</button>
+							</div>
+						</fieldset>
+					</form>
+				</div>
+			</div>
+		</main>
+		<div th:replace="~{user/common/footer :: footer_fragment}"></div>
+	</div>
+</body>
+
+</html>


### PR DESCRIPTION
## チケット
https://github.com/Makoto-Ueno/spring_ec_site/issues/54
## 実装内容
ユーザー側ユーザー登録画面実装
## 確認したこと
バリデーションメッセージ、ユーザーの新規登録
## やらなかったこと
新規登録後の画面遷移先（本来はログイン画面ですがまだ作成していないため、インデックスに遷移するようになっています）